### PR TITLE
[Fix] get assets files recursively

### DIFF
--- a/assets/src/main/java/com/wshunli/assets/CopyCreator.java
+++ b/assets/src/main/java/com/wshunli/assets/CopyCreator.java
@@ -154,8 +154,8 @@ public final class CopyCreator {
         try {
             String[] list = context.getAssets().list(oriPath);
             for (String l : list) {
-                int length = context.getAssets().list(l).length;
                 String desPath = oriPath.equals("") ? l : oriPath + "/" + l;
+                int length = context.getAssets().list(desPath).length;
                 if (length == 0) {
                     paths.add(desPath);
                 } else {


### PR DESCRIPTION
the file names of `AssetManager.list(String path)` are relative to 'path'.

`AssetManager.list(String path)`返回的路径是基于参数`path`的相对路径，需要拼接才能得到真实的资源路径。这里假如`oriPath`设置的不是`""`，而是任意Assets子路径的话，则这里枚举出来的路径是错的，无法递归获得Assets下所有文件列。